### PR TITLE
fix(sec): upgrade mysql-connector-java to 8.0.28

### DIFF
--- a/examples/mysql/pom.xml
+++ b/examples/mysql/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.19</version>
+            <version>8.0.28</version>
         </dependency>
 
         <dependency>

--- a/examples/springboot-sample/pom.xml
+++ b/examples/springboot-sample/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>springboot-sample</artifactId>
     <version>1.0</version>
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceEhttps://github.com/ren-jq101/ObjectiveSql.gitncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <core.version>1.4.6</core.version>
         <springboot.version>1.3.4</springboot.version>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.19</version>
+            <version>8.0.28</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Upgrade mysql-connector-java from 8.0.19 to 8.0.28 for vulnerability fix:
- [CVE-2021-2471](https://www.oscs1024.com/hd/MPS-2021-45509)
- [CVE-2022-21363](https://www.oscs1024.com/hd/MPS-2021-36587)